### PR TITLE
go-get-folder-size 递归获取文件夹大小，足够快，可以跑在 go 和 nodejs 中

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@
 * [go-decent-copy](https://github.com/hugocarreira/go-decent-copy) : 文件复制功能库。 
 * [go-exiftool](https://github.com/barasher/go-exiftool) :  为`ExifTool`提供绑定服务,`ExifTool`是一个著名的库,用于从文件（图片、PDF、office...）中提取尽可能多的元数据
 * [go-gtfs](https://github.com/artonge/go-gtfs) :  用`go`加载`gtfs`文件
+* [go-get-folder-size](https://github.com/markthree/go-get-folder-size) :  递归获取文件夹大小，足够快，可以跑在 go 和 nodejs 中
 * [gut/yos](https://github.com/1set/gut) :  简单可靠的文件操作包,支持对文件、目录和符号链接的`copy/move/diff/list`。
 * [notify](https://github.com/rjeczalik/notify) : 类似 `os/signal`的文件系统提示库,具有简单的 API. 
 * [opc](https://github.com/qmuntal/opc) :   为` Go `加载` Open Packaging Conventions (OPC) `文件


### PR DESCRIPTION
# cli

我们同样用 cli 计算 184,046 个文件，35,185 个文件夹，共 7 GB 左右的目录

node 实现的 [get-folder-size](https://github.com/alessioalex/get-folder-size)，要 11.5s 👇

![image](https://user-images.githubusercontent.com/36569518/223080579-4e5958c5-7b3b-4f56-adf0-f5ef8a3782cd.png)


用 go 重写的 [go-get-folder-size](https://github.com/markthree/go-get-folder-size)，只需要 1.7s 

![image](https://user-images.githubusercontent.com/36569518/223080623-b340f18b-61d3-43f7-b2f5-0e50a0cf47de.png)

# program

也支持 nodejs 和 go 程序式调用

## 支持 nodejs
```js
import {
	getFolderSize,
	getFolderSizeBin,
	getFolderSizeWasm
} from 'go-get-folder-size'

const base = './' // 你想要获取的目录

await getFolderSizeBin(base) // 二进制 go，最快

await getFolderSize(base) // 原生 node

await getFolderSizeWasm(base) // Wasm go，最慢 🥵
```

# 支持 go

```go
package main

import (
	getFolderSize "github.com/markthree/go-get-folder-size/src"
)

func main() {
	size, err := getFolderSize.Parallel("./") // 并发计算，超级快
}
```
